### PR TITLE
config: add domains for aquariuslt

### DIFF
--- a/src/domains.yml
+++ b/src/domains.yml
@@ -2,3 +2,5 @@ domains:
   - views.show
   - docs.views.show
   - unix.bio
+  - zexo.dev
+  - blog.aquariuslt.com


### PR DESCRIPTION
add domains below:
- zexo.dev
- blog.aquariuslt.com (alias for zexo.dev)