### PR TITLE
Add my blog domain konomo.now.sh

### DIFF
--- a/src/domains.yml
+++ b/src/domains.yml
@@ -6,3 +6,4 @@ domains:
   - blog.aquariuslt.com
   - rokkey.com
   - contributors.zeit-ui.co
+  - konomo.now.sh


### PR DESCRIPTION
As the title.
I am planning to migrate to your unix.co blog template, so I added my domain here for preparation.